### PR TITLE
Remove void in functions parameters

### DIFF
--- a/GUIDELINE.md
+++ b/GUIDELINE.md
@@ -8,15 +8,15 @@ Notable C++ naming rules followed are :
 ```C++
     constexpr int MyConstantInt = 42; // Global constants
 
-    Foo GetSomeFoo(void); // Global scoped functions
+    Foo GetSomeFoo(); // Global scoped functions
 
     class Foo { // Classes
     public:
         int myInt; // Public members
 
-        void bar(void); // Member functions
+        void bar(); // Member functions
 
-        static void Bar(void); // Static functions
+        static void Bar(); // Static functions
 
     private:
         int _myInt; // Private members
@@ -28,13 +28,13 @@ Notable C++ naming rules followed are :
 # Getter / Setters
 If the concerned type is scalar (can be cheaply copied) then get/set functions look like :
 ```C++
-Type getType(void) const noexcept; // Constant getter
-void setType(void) noexcept; // Setter
+Type getType() const noexcept; // Constant getter
+void setType() noexcept; // Setter
 ```
 
 If the concerned type isn't scalar (can't be cheaply copied) then get/set functions look like :
 ```C++
 // This allows end-user to choose how to deal with the memory. Best example is copy vs move semantics.
-Type &getType(void) noexcept; // Mutable reference getter
-const Type &getType(void) const noexcept; // Constant reference getter
+Type &getType() noexcept; // Mutable reference getter
+const Type &getType() const noexcept; // Constant reference getter
 ```

--- a/HELLO.md
+++ b/HELLO.md
@@ -10,7 +10,7 @@ Let's say you have a class **Server**.
 	class Server {
 	public:
 		// Set the pipeline module and configuration paths and load modules
-		Server(void) : _pipeline("ModuleDir", "ConfigDir") {
+		Server() : _pipeline("ModuleDir", "ConfigDir") {
 			_pipeline.loadModules();
 		}
 
@@ -48,11 +48,11 @@ Now you need to create your first module. Let's create two of them as a demonstr
 class Hello : public oZ::IModule
 {
 public:
-	Hello(void) = default;
-	virtual ~Hello(void) = default;
+	Hello() = default;
+	virtual ~Hello() = default;
 
-	virtual const char *getName(void) const { return "Hello"; }
-	virtual Dependencies getDependencies(void) const noexcept { return { "World" }; }
+	virtual const char *getName() const { return "Hello"; }
+	virtual Dependencies getDependencies() const noexcept { return { "World" }; }
 
 	// Register your callback to the pipeline
 	virtual void onRegisterCallbacks(Pipeline &pipeline) {
@@ -74,7 +74,7 @@ private:
 /* --- Hello.cpp --- */
 #include "Hello.hpp"
 
-extern "C" oZ::ModulePtr CreateModule(void) { return std::make_shared<Hello>(); }
+extern "C" oZ::ModulePtr CreateModule() { return std::make_shared<Hello>(); }
 ```
 
 ```C++
@@ -87,11 +87,11 @@ extern "C" oZ::ModulePtr CreateModule(void) { return std::make_shared<Hello>(); 
 class World : public oZ::IModule
 {
 public:
-	World(void) = default;
-	virtual ~World(void) = default;
+	World() = default;
+	virtual ~World() = default;
 
-	virtual const char *getName(void) const { return "World"; }
-	virtual Dependencies getDependencies(void) const noexcept { return { "Hello" }; }
+	virtual const char *getName() const { return "World"; }
+	virtual Dependencies getDependencies() const noexcept { return { "Hello" }; }
 
 	// Register your callback to the pipeline
 	virtual void onRegisterCallbacks(Pipeline &pipeline) {
@@ -112,5 +112,5 @@ public:
 /* --- World.cpp --- */
 #include "World.hpp"
 
-extern "C" oZ::ModulePtr CreateModule(void) { return std::make_shared<World>(); }
+extern "C" oZ::ModulePtr CreateModule() { return std::make_shared<World>(); }
 ```

--- a/MODULE.md
+++ b/MODULE.md
@@ -5,7 +5,7 @@ It means that you must compile every module independently.
 For that you must implement your modules deriving from **oZ::IModule** interface.
 Last, you will need an instantiation function:
 ```C++
-extern "C" ModulePtr CreateModule(void) { return std::make_shared<MyModule>(); }
+extern "C" ModulePtr CreateModule() { return std::make_shared<MyModule>(); }
 ```
 The API already does the dynamic library loading for you so you can focus more on creating modules.
 
@@ -48,7 +48,7 @@ bool MyModule::myCallback(oZ::Context &context)
 Each module have a set of virtual function to be override. Actually, only 2 of them are pure virtual :
 ```C++
 // Get the raw string name of module instance
-virtual const char *getName(void) const = 0;
+virtual const char *getName() const = 0;
 
 // Register module's callbacks to the pipeline
 virtual void onRegisterCallbacks(Pipeline &pipeline) = 0;
@@ -62,7 +62,7 @@ class HTTPModule : public oZ::IModule
 {
 public:
 	// Get the raw string name of module instance
-	virtual const char *getName(void) const { return "HTTPModule"; }
+	virtual const char *getName() const { return "HTTPModule"; }
 
 	// Register module's callbacks to the pipeline
 	virtual void onRegisterCallbacks(oZ::Pipeline &pipeline) {
@@ -87,7 +87,7 @@ And that's it ! You don't have to implement anything else to create an independe
 However, there are more virtual functions for more complex needs. These functions are default-implemented to let you the choice of using them or not.
 ```C++
 // Get the list of dependencies (as a vector of raw string, see function getName above)
-virtual Dependencies getDependencies(void) const noexcept;
+virtual Dependencies getDependencies() const noexcept;
 
 // Given a pipeline reference, find each dependent module to store them internally
 virtual void onRetreiveDependencies(Pipeline &pipeline);
@@ -104,18 +104,18 @@ Let's first see how dependencies are handled given a short example:
 class ChildModule : public oZ::IModule
 {
 public:
-	virtual const char *getName(void) const { return "Child"; }
+	virtual const char *getName() const { return "Child"; }
 	virtual void onRegisterCallbacks(oZ::Pipeline &pipeline) { ... }
 };
 
 class RootModule : public oZ::IModule
 {
 public:
-	virtual const char *getName(void) const { return "Root"; }
+	virtual const char *getName() const { return "Root"; }
 	virtual void onRegisterCallbacks(oZ::Pipeline &pipeline) { ... }
 
 	// Return the list of dependencies
-	virtual Dependencies getDependencies(void) const noexcept { return { "Child" }; }
+	virtual Dependencies getDependencies() const noexcept { return { "Child" }; }
 
 	// Find dependencies and store them before any process for performance reasons
 	virtual void onRetreiveDependencies(oZ::Pipeline &pipeline) {
@@ -140,7 +140,7 @@ class MyModule : public oZ::IModule
 public:
 	static const auto *FileName = "MyModule.conf";
 
-	virtual const char *getName(void) const { return "My" };
+	virtual const char *getName() const { return "My" };
 	virtual void onRegisterCallbacks(oZ::Pipeline &pipeline) { ... }
 
 	// Open configuration file and load some properties using MyCustomConfigLoader

--- a/Tests/Medias/FooModule.cpp
+++ b/Tests/Medias/FooModule.cpp
@@ -7,4 +7,4 @@
 
 #include "FooModule.hpp"
 
-extern "C" oZ::ModulePtr CreateModule(void) { return std::make_shared<FooModule>(); }
+extern "C" oZ::ModulePtr CreateModule() { return std::make_shared<FooModule>(); }

--- a/Tests/Medias/FooModule.hpp
+++ b/Tests/Medias/FooModule.hpp
@@ -12,6 +12,6 @@
 class FooModule : public oZ::IModule
 {
 public:
-    virtual const char *getName(void) const { return "Foo"; }
+    virtual const char *getName() const { return "Foo"; }
     virtual void onRegisterCallbacks(oZ::Pipeline &) {}
 };

--- a/Tests/tests_DynamicLoader.cpp
+++ b/Tests/tests_DynamicLoader.cpp
@@ -25,7 +25,7 @@ Test(DynamicLoader, Basics)
     auto handler = loader.load("./libFoo" + Extension);
     cr_assert(handler);
 
-    auto function = loader.getFunction<oZ::ModulePtr(*)(void)>(handler, "CreateModule");
+    auto function = loader.getFunction<oZ::ModulePtr(*)()>(handler, "CreateModule");
     cr_assert(function);
 
     auto module = (*function)();

--- a/Tests/tests_ILogger.cpp
+++ b/Tests/tests_ILogger.cpp
@@ -21,11 +21,11 @@ public:
 class BasicLogger : public ILogger
 {
 public:
-    virtual ~BasicLogger(void) = default;
+    virtual ~BasicLogger() = default;
 
     virtual void onLog(Level, const std::string &) {}
 
-    virtual const char *getName(void) const { return "BasicLogger"; }
+    virtual const char *getName() const { return "BasicLogger"; }
 };
 
 Test(ILogger, Basics)

--- a/Tests/tests_Log.cpp
+++ b/Tests/tests_Log.cpp
@@ -22,14 +22,14 @@ class TestLogger : public ILogger
 {
 public:
     TestLogger(std::string &content) : _content(content) {}
-    virtual ~TestLogger(void) = default;
+    virtual ~TestLogger() = default;
 
     virtual void onLog(Level, const std::string &message) {
         _content += message;
         _content += '\n';
     }
 
-    virtual const char *getName(void) const { return "TestLogger"; }
+    virtual const char *getName() const { return "TestLogger"; }
 
     virtual void onRegisterCallbacks(Pipeline &) {}
 

--- a/Tests/tests_Pipeline.cpp
+++ b/Tests/tests_Pipeline.cpp
@@ -40,7 +40,7 @@ class C;
 class A : public IModule
 {
 public:
-    virtual const char *getName(void) const { return "A"; }
+    virtual const char *getName() const { return "A"; }
 
     virtual void onRegisterCallbacks(Pipeline &pipeline) {
         pipeline.registerCallback(State::Parse, Priority::Independent, this, &A::foo);
@@ -54,7 +54,7 @@ public:
 
     virtual void onLoadConfigurationFile(const std::string &) { configured = true; }
 
-    virtual Dependencies getDependencies(void) const noexcept { return { "B", "C" }; }
+    virtual Dependencies getDependencies() const noexcept { return { "B", "C" }; }
 
     bool foo(Context &) { ++x; return true; }
 
@@ -67,7 +67,7 @@ public:
 class B : public IModule
 {
 public:
-    virtual const char *getName(void) const { return "B"; }
+    virtual const char *getName() const { return "B"; }
 
     virtual void onRegisterCallbacks(Pipeline &pipeline) {
         pipeline.registerCallback(State::Interpret, Priority::ASAP, [this](Context &) { ++x; return false; });
@@ -80,7 +80,7 @@ public:
 class C : public IModule
 {
 public:
-    virtual const char *getName(void) const { return "C"; }
+    virtual const char *getName() const { return "C"; }
 
     virtual void onRegisterCallbacks(Pipeline &pipeline) {
         pipeline.registerCallback(State::Parse, Priority::Independent, [this](Context &) { ++x; return true; });
@@ -123,7 +123,7 @@ Test(Pipeline, ABC)
 class Abis : public A
 {
 public:
-    virtual Dependencies getDependencies(void) const noexcept { return { "B", "E" }; }
+    virtual Dependencies getDependencies() const noexcept { return { "B", "E" }; }
 };
 
 class AbisPipeline : public Pipeline

--- a/openZia/Context.cpp
+++ b/openZia/Context.cpp
@@ -15,7 +15,7 @@ Context::Context(Packet &&packet)
 {
 }
 
-bool Context::nextState(void) noexcept
+bool Context::nextState() noexcept
 {
     switch (getState()) {
     case State::Error:

--- a/openZia/Context.hpp
+++ b/openZia/Context.hpp
@@ -55,7 +55,7 @@ public:
     /**
      * @brief Construct a new Context object
      */
-    Context(void) = default;
+    Context() = default;
 
     /**
      * @brief Construct a new Context object using a packet
@@ -75,42 +75,42 @@ public:
     /**
      * @brief Destroy the Context object
      */
-    ~Context(void) = default;
+    ~Context() = default;
 
     /**
      * @brief Get the network Packet of the context
      */
-    [[nodiscard]] Packet &getPacket(void) noexcept { return _packet; }
+    [[nodiscard]] Packet &getPacket() noexcept { return _packet; }
 
     /**
      * @brief Get the network Packet of the context (constant)
      */
-    [[nodiscard]] const Packet &getPacket(void) const noexcept { return _packet; }
+    [[nodiscard]] const Packet &getPacket() const noexcept { return _packet; }
 
     /**
      * @brief Get the Request of the HTTP context
      */
-    [[nodiscard]] HTTP::Request &getRequest(void) noexcept { return _request; }
+    [[nodiscard]] HTTP::Request &getRequest() noexcept { return _request; }
 
     /**
      * @brief Get the Request of the HTTP context (constant)
      */
-    [[nodiscard]] const HTTP::Request &getRequest(void) const noexcept { return _request; }
+    [[nodiscard]] const HTTP::Request &getRequest() const noexcept { return _request; }
 
     /**
      * @brief Get the Response of the HTTP context
      */
-    [[nodiscard]] HTTP::Response &getResponse(void) noexcept { return _response; }
+    [[nodiscard]] HTTP::Response &getResponse() noexcept { return _response; }
 
     /**
      * @brief Get the Response of the HTTP context (constant)
      */
-    [[nodiscard]] const HTTP::Response &getResponse(void) const noexcept { return _response; }
+    [[nodiscard]] const HTTP::Response &getResponse() const noexcept { return _response; }
 
     /**
      * @brief Get the current context' state
      */
-    [[nodiscard]] State getState(void) const noexcept { return _state; }
+    [[nodiscard]] State getState() const noexcept { return _state; }
 
     /**
      * @brief Set the current context' state
@@ -121,32 +121,32 @@ public:
      * @brief Set internal state to the next one
      *  Return true if the state has changed (and the current state is neither Error nor Completed)
      */
-    bool nextState(void) noexcept;
+    bool nextState() noexcept;
 
     /**
      * @brief Set nternal state to Error
      */
-    void setErrorState(void) { _state = State::Error; }
+    void setErrorState() { _state = State::Error; }
 
     /**
      * @brief Fast error check
      */
-    [[nodiscard]] bool hasError(void) const noexcept { return getState() == State::Error; }
+    [[nodiscard]] bool hasError() const noexcept { return getState() == State::Error; }
 
     /**
      * @brief Fast completion check
      */
-    [[nodiscard]] bool isCompleted(void) const noexcept { return getState() == State::Completed; }
+    [[nodiscard]] bool isCompleted() const noexcept { return getState() == State::Completed; }
 
     /**
      * @brief Tell that the Context is not constant and thus can't be cached
      */
-    void notConstant(void) noexcept { _constant = false; }
+    void notConstant() noexcept { _constant = false; }
 
     /**
      * @brief Check if the current Context's state is constant (and if it can be cached)
      */
-    [[nodiscard]] bool isConstant(void) const noexcept { return _constant; }
+    [[nodiscard]] bool isConstant() const noexcept { return _constant; }
 
 private:
     Packet _packet;

--- a/openZia/DynamicLoader.cpp
+++ b/openZia/DynamicLoader.cpp
@@ -47,7 +47,7 @@ DynamicHandler DynamicLoader::load(const std::string &path)
     return handler;
 }
 
-void DynamicLoader::release(void)
+void DynamicLoader::release()
 {
     for (auto &[handler, name] : _handlers) {
 #if defined(SYSTEM_LINUX)
@@ -59,7 +59,7 @@ void DynamicLoader::release(void)
     _handlers.clear();
 }
 
-std::string DynamicLoader::getLastError(void) const noexcept
+std::string DynamicLoader::getLastError() const noexcept
 {
 #if defined(SYSTEM_LINUX)
     return ::dlerror();

--- a/openZia/DynamicLoader.hpp
+++ b/openZia/DynamicLoader.hpp
@@ -23,12 +23,12 @@ public:
     /**
      * @brief Construct a new Dynamic Loader object
      */
-    DynamicLoader(void) = default;
+    DynamicLoader() = default;
 
     /**
      * @brief Destroy the Dynamic Loader object and release its content
      */
-    ~DynamicLoader(void);
+    ~DynamicLoader();
 
     /**
      * @brief Load a dynamic library
@@ -51,12 +51,12 @@ public:
      *  Call this function after every instances aquired from libraries are destroyed.
      *  If you destroy instances after, the virtual destructor will be unloaded and your program will crash.
      */
-    void release(void);
+    void release();
 
     /**
      * @brief Get the last error as string
      */
-    [[nodiscard]] std::string getLastError(void) const noexcept;
+    [[nodiscard]] std::string getLastError() const noexcept;
 
     /**
      * @brief Get the name of a handler

--- a/openZia/Endpoint.cpp
+++ b/openZia/Endpoint.cpp
@@ -11,7 +11,7 @@
 
 using namespace oZ;
 
-std::string Endpoint::getAddress(void) const noexcept
+std::string Endpoint::getAddress() const noexcept
 {
     auto *ptr = reinterpret_cast<const std::uint8_t *>(&_ip);
     std::string res;

--- a/openZia/Endpoint.hpp
+++ b/openZia/Endpoint.hpp
@@ -26,7 +26,7 @@ public:
     /**
      * @brief Construct a new Endpoint object
      */
-    Endpoint(void) = default;
+    Endpoint() = default;
 
     /**
      * @brief Construct a new Endpoint object using IP as string
@@ -46,7 +46,7 @@ public:
     /**
      * @brief Destroy the Endpoint objecti
      */
-    ~Endpoint(void) = default;
+    ~Endpoint() = default;
 
     /**
      * @brief Equality operator
@@ -58,12 +58,12 @@ public:
      *
      * @return std::string IP Address formated as 'X.X.X.X'
      */
-    std::string getAddress(void) const noexcept;
+    std::string getAddress() const noexcept;
 
     /**
      * @brief Retreive internal ip in 4 bytes
      */
-    IP getAddressValue(void) const noexcept { return _ip; }
+    IP getAddressValue() const noexcept { return _ip; }
 
     /**
      * @brief Set the Address object using a string
@@ -78,7 +78,7 @@ public:
     /**
      * @brief Get internal port
      */
-    Port getPort(void) const noexcept { return _port; }
+    Port getPort() const noexcept { return _port; }
 
     /**
      * @brief Set internal port

--- a/openZia/ILogger.hpp
+++ b/openZia/ILogger.hpp
@@ -14,7 +14,7 @@
 namespace oZ
 {
     class ILogger;
-    
+
     /**
      * @brief Levels of log messages
      */
@@ -46,12 +46,12 @@ public:
     /**
      * @brief Construct a new ILogger object
      */
-    ILogger(void) = default;
+    ILogger() = default;
 
     /**
      * @brief Destroy the ILogger object
      */
-    virtual ~ILogger(void) = default;
+    virtual ~ILogger() = default;
 
     /**
      * @brief Log a single message of given level

--- a/openZia/IModule.hpp
+++ b/openZia/IModule.hpp
@@ -41,9 +41,9 @@ namespace oZ
      * @brief Function signature that each module should respect to get detected and instantied.
      * It musts uses the name 'createModule'.
      *
-     * Example : ModulePtr CreateModule(void) { return std::make_shared<MyModule>(); }
+     * Example : ModulePtr CreateModule() { return std::make_shared<MyModule>(); }
      */
-    using ModuleInstanceFunction = ModulePtr(*)(void);
+    using ModuleInstanceFunction = ModulePtr(*)();
 }
 
 /**
@@ -64,17 +64,17 @@ public:
     /**
      * @brief Construct a new IModule object
      */
-    IModule(void) = default;
+    IModule() = default;
 
     /**
      * @brief Destroy the IModule object
      */
-    virtual ~IModule(void) = default;
+    virtual ~IModule() = default;
 
     /**
      * @brief Get the module name
      */
-    virtual const char *getName(void) const = 0;
+    virtual const char *getName() const = 0;
 
     /**
      * @brief Register module's callbacks in the pipeline
@@ -86,7 +86,7 @@ public:
      *
      *  By default a module has no dependencies
      */
-    virtual Dependencies getDependencies(void) const noexcept { return Dependencies(); }
+    virtual Dependencies getDependencies() const noexcept { return Dependencies(); }
 
     /**
      * @brief This function is called once module registered their callbacks

--- a/openZia/Log.cpp
+++ b/openZia/Log.cpp
@@ -11,7 +11,7 @@
 
 using namespace oZ;
 
-Log &Log::flush(void)
+Log &Log::flush()
 {
     auto &loggers = GetLoggerList();
     auto toLog = _os.str();
@@ -24,7 +24,7 @@ Log &Log::flush(void)
     return *this;
 }
 
-LoggerList &Log::GetLoggerList(void)
+LoggerList &Log::GetLoggerList()
 {
     static LoggerList loggers;
 

--- a/openZia/Log.hpp
+++ b/openZia/Log.hpp
@@ -19,7 +19,7 @@ public:
     /**
      * @brief Construct a new Log object
      */
-    Log(void) = default;
+    Log() = default;
 
     /**
      * @brief Construct a new Log object using a log level
@@ -29,7 +29,7 @@ public:
     /**
      * @brief Destroy the Log object and flush stream
      */
-    ~Log(void) { flush(); }
+    ~Log() { flush(); }
 
     /**
      * @brief Add a value of any type to the stream
@@ -40,7 +40,7 @@ public:
     /**
      * @brief Flush current stream
      */
-    Log &flush(void);
+    Log &flush();
 
     /**
      * @brief Add a new logger into the list
@@ -50,7 +50,7 @@ public:
     /**
      * @brief Get the global logger list
      */
-    static LoggerList &GetLoggerList(void);
+    static LoggerList &GetLoggerList();
 
 
 private:

--- a/openZia/Packet.hpp
+++ b/openZia/Packet.hpp
@@ -18,7 +18,7 @@ public:
     /**
      * @brief Construct a new Packet object
      */
-    Packet(void) = default;
+    Packet() = default;
 
     /**
      * @brief Construct a new Packet object using byteArray and an endpoint
@@ -28,22 +28,22 @@ public:
     /**
      * @brief Destroy the Packet object
      */
-    ~Packet(void) = default;
+    ~Packet() = default;
 
     /**
      * @brief Get the ByteArray of the context
      */
-    [[nodiscard]] ByteArray &getByteArray(void) noexcept { return _byteArray; }
+    [[nodiscard]] ByteArray &getByteArray() noexcept { return _byteArray; }
 
     /**
      * @brief Get the ByteArray of the context (constant)
      */
-    [[nodiscard]] const ByteArray getByteArray(void) const noexcept { return _byteArray; }
+    [[nodiscard]] const ByteArray getByteArray() const noexcept { return _byteArray; }
 
     /**
      * @brief Get the current context' state
      */
-    [[nodiscard]] Endpoint getEndpoint(void) const noexcept { return _endpoint; }
+    [[nodiscard]] Endpoint getEndpoint() const noexcept { return _endpoint; }
 
     /**
      * @brief Set the Endpoint target
@@ -53,17 +53,17 @@ public:
     /**
      * @brief Get the Encryption Key
      */
-    [[nodiscard]] std::string &getEncryptionKey(void) noexcept { return _encryptionKey; }
+    [[nodiscard]] std::string &getEncryptionKey() noexcept { return _encryptionKey; }
 
     /**
      * @brief Get the Encryption Key (constant)
      */
-    [[nodiscard]] const std::string &getEncryptionKey(void) const noexcept { return _encryptionKey; }
+    [[nodiscard]] const std::string &getEncryptionKey() const noexcept { return _encryptionKey; }
 
     /**
      * @brief Check the usage of encryption port (default HTTPS is 443)
      */
-    [[nodiscard]] bool hasEncryption(void) const noexcept { return _useEncryption; }
+    [[nodiscard]] bool hasEncryption() const noexcept { return _useEncryption; }
 
     /**
      * @brief Set the encryption state

--- a/openZia/Pipeline.cpp
+++ b/openZia/Pipeline.cpp
@@ -25,7 +25,7 @@ Pipeline::Pipeline(std::string &&moduleDir, std::string &&configurationDir)
 {
 }
 
-void Pipeline::loadModules(void)
+void Pipeline::loadModules()
 {
     for (auto &state : _pipeline)
         state.clear();
@@ -57,7 +57,7 @@ void Pipeline::onLoadModules(const std::string &directoryPath)
         else if (auto ext = file.path().extension().string(); ext != ".dll" && ext != ".so")
             continue;
         auto handler = _dynamicLoader.load(file.path());
-        auto function = _dynamicLoader.getFunction<ModulePtr(*)(void)>(handler, "CreateModule");
+        auto function = _dynamicLoader.getFunction<ModulePtr(*)()>(handler, "CreateModule");
         _modules.emplace_back((*function)());
     }
 }
@@ -89,7 +89,7 @@ void Pipeline::triggerContextStateCallbacks(Context &context)
     }
 }
 
-void Pipeline::checkModulesDependencies(void)
+void Pipeline::checkModulesDependencies()
 {
     for (const auto &module : _modules) {
         for (const auto *dependencie : module->getDependencies())
@@ -106,7 +106,7 @@ void Pipeline::checkModuleDependency(const ModulePtr &module, const char *depend
         throw std::logic_error(std::string("Pipeline::checkModuleDependencies: ") + module->getName() + "' requires missing module '" + dependency + '\'');
 }
 
-void Pipeline::createPipeline(void)
+void Pipeline::createPipeline()
 {
     if (!_configurationDir.empty() && _configurationDir.back() != '/')
         _configurationDir.push_back('/');

--- a/openZia/Pipeline.hpp
+++ b/openZia/Pipeline.hpp
@@ -70,7 +70,7 @@ public:
     /**
      * @brief Destroy the Pipeline object
      */
-    virtual ~Pipeline(void) = default;
+    virtual ~Pipeline() = default;
 
     /**
      * @brief Find modules and load them into the pipeline.
@@ -80,7 +80,7 @@ public:
      *      3) Build the internal pipeline with it.
      *      4) Load configuration files of each modules
      */
-    void loadModules(void);
+    void loadModules();
 
     /**
      * @brief Inserts a callback handler into the pipeline with given state and priority
@@ -105,12 +105,12 @@ public:
     /**
      * @brief Get internal loaded modules
      */
-    [[nodiscard]] ModuleList &getModules(void) noexcept { return _modules; }
+    [[nodiscard]] ModuleList &getModules() noexcept { return _modules; }
 
     /**
      * @brief Get internal loaded modules (const)
      */
-    [[nodiscard]] const ModuleList &getModules(void) const noexcept { return _modules; }
+    [[nodiscard]] const ModuleList &getModules() const noexcept { return _modules; }
 
     /**
      * @brief Emplaces a new module in the pipeline.
@@ -129,7 +129,7 @@ public:
      * @brief Find a module of Type in internal module list returning it as a shared pointer.
      */
     template<typename Type = IModule>
-    [[nodiscard]] std::shared_ptr<Type> findModule(void) const;
+    [[nodiscard]] std::shared_ptr<Type> findModule() const;
 
 protected:
     /**
@@ -151,7 +151,7 @@ private:
     /**
      * @brief Check if every modules dependencies are present.
      */
-    void checkModulesDependencies(void);
+    void checkModulesDependencies();
 
     /**
      * @brief Check if a module's dependency matches a currently loaded module
@@ -162,7 +162,7 @@ private:
      * @brief Create internal pipeline with the current internal modules.
      *  This function will first register modules' callbacks, then retreive dependencies of them to finally load their configuration files.
      */
-    void createPipeline(void);
+    void createPipeline();
 
     /**
      * @brief Trigger every callback of a given context's state

--- a/openZia/Pipeline.ipp
+++ b/openZia/Pipeline.ipp
@@ -20,7 +20,7 @@ void oZ::Pipeline::addModule(Args &&...args)
 }
 
 template<typename Type>
-std::shared_ptr<Type> oZ::Pipeline::findModule(void) const
+std::shared_ptr<Type> oZ::Pipeline::findModule() const
 {
     for (auto &module : _modules)
         if (auto ptr = std::dynamic_pointer_cast<Type>(module); ptr)

--- a/openZia/RequestHTTP.hpp
+++ b/openZia/RequestHTTP.hpp
@@ -34,12 +34,12 @@ public:
     /**
      * @brief Destroy the Request object
      */
-    ~Request(void) = default;
+    ~Request() = default;
 
     /**
      * @brief Get request's method
      */
-    [[nodiscard]] Method getMethod(void) const noexcept { return _method; }
+    [[nodiscard]] Method getMethod() const noexcept { return _method; }
 
     /**
      * @brief Set request's method
@@ -49,17 +49,17 @@ public:
     /**
      * @brief Get request's URI reference
      */
-    [[nodiscard]] URI &getURI(void) noexcept { return _uri; }
+    [[nodiscard]] URI &getURI() noexcept { return _uri; }
 
     /**
      * @brief Get request's URI constant reference
      */
-    [[nodiscard]] const URI &getURI(void) const noexcept { return _uri; }
+    [[nodiscard]] const URI &getURI() const noexcept { return _uri; }
 
     /**
      * @brief Get request's version
      */
-    [[nodiscard]] Version getVersion(void) const noexcept { return _version; }
+    [[nodiscard]] Version getVersion() const noexcept { return _version; }
 
     /**
      * @brief Set request's version
@@ -69,12 +69,12 @@ public:
     /**
      * @brief Get the response's header reference
      */
-    [[nodiscard]] Header &getHeader(void) noexcept { return _header; }
+    [[nodiscard]] Header &getHeader() noexcept { return _header; }
 
     /**
      * @brief Get the response's header constant reference
      */
-    [[nodiscard]] const Header &getHeader(void) const noexcept { return _header; }
+    [[nodiscard]] const Header &getHeader() const noexcept { return _header; }
 
 private:
     Method _method = Method::NullMethod;

--- a/openZia/ResponseHTTP.hpp
+++ b/openZia/ResponseHTTP.hpp
@@ -37,12 +37,12 @@ public:
     /**
      * @brief Destroy the Response object
      */
-    ~Response(void) = default;
+    ~Response() = default;
 
     /**
      * @brief Get request's code
      */
-    [[nodiscard]] Code getCode(void) const noexcept { return _code; }
+    [[nodiscard]] Code getCode() const noexcept { return _code; }
 
     /**
      * @brief Set request's code
@@ -52,27 +52,27 @@ public:
     /**
      * @brief Get request's Reason reference
      */
-    [[nodiscard]] Reason &getReason(void) noexcept { return _reason; }
+    [[nodiscard]] Reason &getReason() noexcept { return _reason; }
 
     /**
      * @brief Get request's Reason constant reference
      */
-    [[nodiscard]] const Reason &getReason(void) const noexcept { return _reason; }
+    [[nodiscard]] const Reason &getReason() const noexcept { return _reason; }
 
     /**
      * @brief Get request's Body reference
      */
-    [[nodiscard]] Body &getBody(void) noexcept { return _body; }
+    [[nodiscard]] Body &getBody() noexcept { return _body; }
 
     /**
      * @brief Get request's Body constant reference
      */
-    [[nodiscard]] const Body &getBody(void) const noexcept { return _body; }
+    [[nodiscard]] const Body &getBody() const noexcept { return _body; }
 
     /**
      * @brief Get request's version
      */
-    [[nodiscard]] Version getVersion(void) const noexcept { return _version; }
+    [[nodiscard]] Version getVersion() const noexcept { return _version; }
 
     /**
      * @brief Set request's version
@@ -82,12 +82,12 @@ public:
     /**
      * @brief Get the response's header reference
      */
-    [[nodiscard]] Header &getHeader(void) noexcept { return _header; }
+    [[nodiscard]] Header &getHeader() noexcept { return _header; }
 
     /**
      * @brief Get the response's header constant reference
      */
-    [[nodiscard]] const Header &getHeader(void) const noexcept { return _header; }
+    [[nodiscard]] const Header &getHeader() const noexcept { return _header; }
 
 private:
     Code _code = Code::Undefined;


### PR DESCRIPTION
* In C, we use `void` in function parameters to explicitly say the function takes no parameters.  
The following C code compiles :
```c
#include <stdio.h>

// Add void in the parameters and it doesn't compile anymore.
void print_hello()
{
    puts("Hello world");
}

int main()
{
    print_hello(42, 21, "Foo");
}
```
* In C++, the explicit mention of `void` is not necessary because the code will not compile anyways.

**This pull request removes the unnecessary voids in function parameters.**  
I did not touch html, js and tex files.