### PR TITLE
Catch module exceptions

### DIFF
--- a/openZia/Pipeline.cpp
+++ b/openZia/Pipeline.cpp
@@ -86,8 +86,14 @@ void Pipeline::runPipeline(Context &context)
 void Pipeline::triggerContextStateCallbacks(Context &context)
 {
     for (const auto &callback : _pipeline[context.getState()]) {
-        if (!callback.second(context))
-            break;
+        try {
+            if (!callback.second(context))
+                break;
+        } catch(const std::exception& e) {
+            context.setState(Error);
+            context.getResponse().setCode(HTTP::Code::InternalServerError);
+            context.getResponse().getReason() = "Exception: "s + e.what();
+        }
     }
 }
 


### PR DESCRIPTION
User code in modules cannot be trusted to be exceptions-safe, and one module producing exceptions should not impair other modules. This is a fix of this situation by catching exceptions and automatically using them in the context's response