### PR TITLE
fix: add entry point as macro

### DIFF
--- a/Tests/Medias/FooModule.cpp
+++ b/Tests/Medias/FooModule.cpp
@@ -7,4 +7,4 @@
 
 #include "FooModule.hpp"
 
-extern "C" oZ::IModule *CreateModule(void) { return new FooModule(); }
+OPEN_ZIA_MAKE_ENTRY_POINT(FooModule);

--- a/Tests/tests_DynamicLoader.cpp
+++ b/Tests/tests_DynamicLoader.cpp
@@ -19,7 +19,7 @@ Test(DynamicLoader, Basics)
     auto handler = loader.load("./libFoo" + std::string(SHARED_LIB_EXT));
     cr_assert(handler);
 
-    auto function = loader.getFunction<oZ::ModuleInstanceFunction>(handler, "CreateModule");
+    auto function = loader.getFunction<oZ::ModuleInstanceFunction>(handler, OPEN_ZIA_ENTRY_POINT_AS_STRING);
     cr_assert(function);
 
     oZ::ModulePtr module { (*function)() };

--- a/openZia/EntryPoint.hpp
+++ b/openZia/EntryPoint.hpp
@@ -1,0 +1,36 @@
+/*
+** EPITECH PROJECT, 2020
+** openZia
+** File description:
+** EntryPoint
+*/
+
+#ifndef ENTRYPOINT_HPP_
+# define ENTRYPOINT_HPP_
+
+# include "OperatingSystem.hpp"
+
+# ifndef EXTERN_C
+#  ifdef __cplusplus
+#   define EXTERN_C extern "C"
+#  else
+#   define EXTERN_C extern
+#  endif
+# endif
+
+# if defined(SYSTEM_LINUX)
+#  define OPEN_ZIA_EXPORT
+# elif defined(SYSTEM_WINDOWS)
+#  define OPEN_ZIA_EXPORT __declspec(dllexport) __stdcall
+# endif
+
+# define OPEN_ZIA_ENTRY_POINT CreateModule
+# define OPEN_ZIA_ENTRY_POINT_AS_STRING "CreateModule"
+
+# define OPEN_ZIA_MAKE_ENTRY_POINT(class)                           \
+    EXTERN_C OPEN_ZIA_EXPORT oZ::IModule *OPEN_ZIA_ENTRY_POINT()    \
+    {                                                               \
+        return new class();                                         \
+    }                                                               \
+
+#endif /* !ENTRYPOINT_HPP_ */

--- a/openZia/IModule.hpp
+++ b/openZia/IModule.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Context.hpp"
+#include "EntryPoint.hpp"
 
 namespace oZ
 {

--- a/openZia/Pipeline.cpp
+++ b/openZia/Pipeline.cpp
@@ -72,7 +72,7 @@ void Pipeline::onLoadModules(const std::string &directoryPath)
         else if (auto ext = file.path().extension().string(); ext != std::string(SHARED_LIB_EXT))
             continue;
         auto handler = _dynamicLoader.load(file.path().string());
-        auto function = _dynamicLoader.getFunction<ModuleInstanceFunction>(handler, "CreateModule");
+        auto function = _dynamicLoader.getFunction<ModuleInstanceFunction>(handler, OPEN_ZIA_ENTRY_POINT_AS_STRING);
         addModule(ModulePtr((*function)()));
     }
 }


### PR DESCRIPTION
You will write :
`OPEN_ZIA_MAKE_ENTRY_POINT(FooModule);`
Instead of :
`extern "C" oZ::IModule *CreateModule(void) { return new FooModule(); }`

In each of your module