### PR TITLE
fix: remove __stdcall when importing DLL

### DIFF
--- a/openZia/EntryPoint.hpp
+++ b/openZia/EntryPoint.hpp
@@ -21,7 +21,7 @@
 # if defined(SYSTEM_LINUX)
 #  define OPEN_ZIA_EXPORT
 # elif defined(SYSTEM_WINDOWS)
-#  define OPEN_ZIA_EXPORT __declspec(dllexport) __stdcall
+#  define OPEN_ZIA_EXPORT __declspec(dllexport)
 # endif
 
 # define STR_VALUE(arg) #arg


### PR DESCRIPTION
Hi,

openZia doesn't compile on Windows.

I just changed :

`extern "C" __declspec(dllexport) __stdcall oZ::IModule * CreateModule() { return new zia::SSL; }`
to
 `extern "C" __declspec(dllexport) oZ::IModule * CreateModule() { return new zia::SSL; }`

Considering the default is already __stdcall. I suggest to remove it.
 (source : https://stackoverflow.com/questions/6334283/declspec-and-stdcall-vs-declspec-only)

An alternative, in order to keep the "__stdcall" would be to change the syntax to :
`extern "C" __declspec(dllexport) oZ::IModule * __stdcall CreateModule() { return new zia::SSL; }` (it compiles)

Ty for the API.