### PR TITLE
fix: include winsock2 | refactor: inline keyword

### DIFF
--- a/openZia/Context.hpp
+++ b/openZia/Context.hpp
@@ -80,42 +80,42 @@ public:
     /**
      * @brief Get the network Packet of the context
      */
-    [[nodiscard]] Packet &getPacket(void) noexcept { return _packet; }
+    [[nodiscard]] inline Packet &getPacket(void) noexcept { return _packet; }
 
     /**
      * @brief Get the network Packet of the context (constant)
      */
-    [[nodiscard]] const Packet &getPacket(void) const noexcept { return _packet; }
+    [[nodiscard]] inline const Packet &getPacket(void) const noexcept { return _packet; }
 
     /**
      * @brief Get the Request of the HTTP context
      */
-    [[nodiscard]] HTTP::Request &getRequest(void) noexcept { return _request; }
+    [[nodiscard]] inline HTTP::Request &getRequest(void) noexcept { return _request; }
 
     /**
      * @brief Get the Request of the HTTP context (constant)
      */
-    [[nodiscard]] const HTTP::Request &getRequest(void) const noexcept { return _request; }
+    [[nodiscard]] inline const HTTP::Request &getRequest(void) const noexcept { return _request; }
 
     /**
      * @brief Get the Response of the HTTP context
      */
-    [[nodiscard]] HTTP::Response &getResponse(void) noexcept { return _response; }
+    [[nodiscard]] inline HTTP::Response &getResponse(void) noexcept { return _response; }
 
     /**
      * @brief Get the Response of the HTTP context (constant)
      */
-    [[nodiscard]] const HTTP::Response &getResponse(void) const noexcept { return _response; }
+    [[nodiscard]] inline const HTTP::Response &getResponse(void) const noexcept { return _response; }
 
     /**
      * @brief Get the current context' state
      */
-    [[nodiscard]] State getState(void) const noexcept { return _state; }
+    [[nodiscard]] inline State getState(void) const noexcept { return _state; }
 
     /**
      * @brief Set the current context' state
      */
-    void setState(const State state) noexcept { _state = state; }
+    inline void setState(const State state) noexcept { _state = state; }
 
     /**
      * @brief Set internal state to the next one
@@ -126,27 +126,27 @@ public:
     /**
      * @brief Set nternal state to Error
      */
-    void setErrorState(void) { _state = State::Error; }
+    inline void setErrorState(void) noexcept { _state = State::Error; }
 
     /**
      * @brief Fast error check
      */
-    [[nodiscard]] bool hasError(void) const noexcept { return getState() == State::Error; }
+    [[nodiscard]] inline bool hasError(void) const noexcept { return getState() == State::Error; }
 
     /**
      * @brief Fast completion check
      */
-    [[nodiscard]] bool isCompleted(void) const noexcept { return getState() == State::Completed; }
+    [[nodiscard]] inline bool isCompleted(void) const noexcept { return getState() == State::Completed; }
 
     /**
      * @brief Tell that the Context is not constant and thus can't be cached
      */
-    void notConstant(void) noexcept { _constant = false; }
+    inline void notConstant(void) noexcept { _constant = false; }
 
     /**
      * @brief Check if the current Context's state is constant (and if it can be cached)
      */
-    [[nodiscard]] bool isConstant(void) const noexcept { return _constant; }
+    [[nodiscard]] inline bool isConstant(void) const noexcept { return _constant; }
 
 private:
     Packet _packet {};

--- a/openZia/DynamicLoader.hpp
+++ b/openZia/DynamicLoader.hpp
@@ -13,9 +13,10 @@
 #include "OperatingSystem.hpp"
 
 #if defined(SYSTEM_LINUX) || defined(SYSTEM_DARWIN)
-#include <dlfcn.h>
+# include <dlfcn.h>
 #elif defined(SYSTEM_WINDOWS)
-#include <Windows.h>
+# include <winsock2.h>
+# include <Windows.h>
 #endif
 
 namespace oZ
@@ -56,7 +57,8 @@ public:
      * @brief Get a function of handler library, returning custom Signature
      */
     template<typename Signature>
-    [[nodiscard]] Signature getFunction(DynamicHandler handler, const std::string &name) { return reinterpret_cast<Signature>(getFunction(handler, name)); }
+    [[nodiscard]] inline Signature getFunction(DynamicHandler handler, const std::string &name)
+        { return reinterpret_cast<Signature>(getFunction(handler, name)); }
 
     /**
      * @brief Release loaded libraries.

--- a/openZia/Endpoint.hpp
+++ b/openZia/Endpoint.hpp
@@ -56,7 +56,7 @@ public:
     /**
      * @brief Equality operator
      */
-    bool operator==(const Endpoint &other) const noexcept { return _ip == other._ip && _port == other._port; }
+    inline bool operator==(const Endpoint &other) const noexcept { return _ip == other._ip && _port == other._port; }
 
     /**
      * @brief Get internal address as formated string
@@ -68,7 +68,7 @@ public:
     /**
      * @brief Retreive internal ip in 4 bytes
      */
-    IP getAddressValue(void) const noexcept { return _ip; }
+    inline IP getAddressValue(void) const noexcept { return _ip; }
 
     /**
      * @brief Set the Address object using a string
@@ -78,17 +78,17 @@ public:
     /**
      * @brief Set the Address object using a 4 byte value
      */
-    void setAddress(const IP ip) { _ip = ip; }
+    inline void setAddress(const IP ip) { _ip = ip; }
 
     /**
      * @brief Get internal port
      */
-    Port getPort(void) const noexcept { return _port; }
+    inline Port getPort(void) const noexcept { return _port; }
 
     /**
      * @brief Set internal port
      */
-    void setPort(const Port port) noexcept { _port = port; }
+    inline void setPort(const Port port) noexcept { _port = port; }
 
 private:
     IP _ip = 0;

--- a/openZia/HeaderHTTP.hpp
+++ b/openZia/HeaderHTTP.hpp
@@ -46,7 +46,7 @@ public:
      * @brief Check existence of a value in the header
      */
     template<typename Literal>
-    [[nodiscard]] bool exists(const Literal &key) const noexcept { return _mmap.find(key) != _mmap.end(); }
+    [[nodiscard]] inline bool exists(const Literal &key) const noexcept { return _mmap.find(key) != _mmap.end(); }
 
     /**
      * @brief Get a value in the header matching a key and an index, and throw if not found
@@ -64,47 +64,47 @@ public:
      * @brief Get a value in the header
      */
     template<typename Literal, typename Literal2>
-    void set(const Literal &key, Literal2 &&value) { _mmap.emplace(key, std::forward<Literal2>(value)); }
+    void inline set(const Literal &key, Literal2 &&value) { _mmap.emplace(key, std::forward<Literal2>(value)); }
 
     /**
      * @brief Count occurences of matching key
      */
     template<typename Literal>
-    [[nodiscard]] std::uint32_t count(const Literal &key) const noexcept { return _mmap.count(key); }
+    [[nodiscard]] inline std::uint32_t count(const Literal &key) const noexcept { return _mmap.count(key); }
 
     /**
      * @brief Get the iterator of matching key
      */
     template<typename Literal>
-    [[nodiscard]] Iterator getIterator(const Literal &key) { return _mmap.find(key); }
+    [[nodiscard]] inline Iterator getIterator(const Literal &key) { return _mmap.find(key); }
 
     /**
      * @brief Get the iterator of matching key
      */
     template<typename Literal>
-    [[nodiscard]] ConstIterator getIterator(const Literal &key) const { return _mmap.find(key); }
+    [[nodiscard]] inline ConstIterator getIterator(const Literal &key) const { return _mmap.find(key); }
 
     /**
      * @brief Get the iterator range of matching key
      */
     template<typename Literal>
-    [[nodiscard]] IteratorRange getIteratorRange(const Literal &key) { return _mmap.equal_range(key); }
+    [[nodiscard]] inline IteratorRange getIteratorRange(const Literal &key) { return _mmap.equal_range(key); }
 
     /**
      * @brief Get the iterator range of matching key
      */
     template<typename Literal>
-    [[nodiscard]] ConstIteratorRange getIteratorRange(const Literal &key) const { return _mmap.equal_range(key); }
+    [[nodiscard]] inline ConstIteratorRange getIteratorRange(const Literal &key) const { return _mmap.equal_range(key); }
 
     /**
      * @brief Get the String Multimap's reference
      */
-    [[nodiscard]] StringMultimap &getStringMultimap(void) noexcept { return _mmap; }
+    [[nodiscard]] inline StringMultimap &getStringMultimap(void) noexcept { return _mmap; }
 
     /**
      * @brief Get the String Multimap's constant reference
      */
-    [[nodiscard]] const StringMultimap &getStringMultimap(void) const noexcept { return _mmap; }
+    [[nodiscard]] inline const StringMultimap &getStringMultimap(void) const noexcept { return _mmap; }
 
 private:
     StringMultimap _mmap {};

--- a/openZia/ILogger.hpp
+++ b/openZia/ILogger.hpp
@@ -61,5 +61,5 @@ public:
     /**
      * @brief The callback register handler is defaulted because your logger may not need it
      */
-    virtual void onRegisterCallbacks(Pipeline &) {}
+    virtual inline void onRegisterCallbacks(Pipeline &) {}
 };

--- a/openZia/IModule.hpp
+++ b/openZia/IModule.hpp
@@ -87,7 +87,7 @@ public:
      *
      *  By default a module has no dependencies
      */
-    virtual Dependencies getDependencies(void) const noexcept { return Dependencies(); }
+    virtual inline Dependencies getDependencies(void) const noexcept { return {}; }
 
     /**
      * @brief This function is called once module registered their callbacks

--- a/openZia/Log.hpp
+++ b/openZia/Log.hpp
@@ -45,7 +45,7 @@ public:
     /**
      * @brief Add a new logger into the list
      */
-    static void AddLogger(LoggerPtr logger) { GetLoggerList().emplace_back(std::move(logger)); }
+    static inline void AddLogger(LoggerPtr logger) { GetLoggerList().emplace_back(std::move(logger)); }
 
     /**
      * @brief Get the global logger list

--- a/openZia/MessageHTTP.hpp
+++ b/openZia/MessageHTTP.hpp
@@ -21,32 +21,32 @@ public:
     /**
      * @brief Get the response's header reference
      */
-    [[nodiscard]] Header &getHeader(void) noexcept { return _header; }
+    [[nodiscard]] inline Header &getHeader(void) noexcept { return _header; }
 
     /**
      * @brief Get the response's header constant reference
      */
-    [[nodiscard]] const Header &getHeader(void) const noexcept { return _header; }
+    [[nodiscard]] inline const Header &getHeader(void) const noexcept { return _header; }
 
     /**
      * @brief Get request's Body reference
      */
-    [[nodiscard]] Body &getBody(void) noexcept { return _body; }
+    [[nodiscard]] inline Body &getBody(void) noexcept { return _body; }
 
     /**
      * @brief Get request's Body constant reference
      */
-    [[nodiscard]] const Body &getBody(void) const noexcept { return _body; }
+    [[nodiscard]] inline const Body &getBody(void) const noexcept { return _body; }
 
     /**
      * @brief Get request's version
      */
-    [[nodiscard]] Version getVersion(void) const noexcept { return _version; }
+    [[nodiscard]] inline Version getVersion(void) const noexcept { return _version; }
 
     /**
      * @brief Set request's version
      */
-    void setVersion(const Version version) noexcept { _version = version; }
+    inline void setVersion(const Version version) noexcept { _version = version; }
 
 private:
     Header _header {};

--- a/openZia/Packet.hpp
+++ b/openZia/Packet.hpp
@@ -34,42 +34,42 @@ public:
     /**
      * @brief Get the ByteArray of the context
      */
-    [[nodiscard]] ByteArray &getByteArray(void) noexcept { return _byteArray; }
+    [[nodiscard]] inline ByteArray &getByteArray(void) noexcept { return _byteArray; }
 
     /**
      * @brief Get the ByteArray of the context (constant)
      */
-    [[nodiscard]] const ByteArray getByteArray(void) const noexcept { return _byteArray; }
+    [[nodiscard]] inline const ByteArray getByteArray(void) const noexcept { return _byteArray; }
 
     /**
      * @brief Get the current context's endpoint
      */
-    [[nodiscard]] Endpoint getEndpoint(void) const noexcept { return _endpoint; }
+    [[nodiscard]] inline Endpoint getEndpoint(void) const noexcept { return _endpoint; }
 
     /**
      * @brief Set the Endpoint target
      */
-    void setEndpoint(const Endpoint endpoint) noexcept { _endpoint = endpoint; }
+    inline void setEndpoint(const Endpoint endpoint) noexcept { _endpoint = endpoint; }
 
     /**
      * @brief Get the context's file descriptor
      */
-    [[nodiscard]] FileDescriptor getFileDescriptor(void) const noexcept { return _fd; }
+    [[nodiscard]] inline FileDescriptor getFileDescriptor(void) const noexcept { return _fd; }
 
     /**
      * @brief Set the context's file descriptor
      */
-    void setFileDescriptor(const FileDescriptor fd) noexcept { _fd = fd; }
+    inline void setFileDescriptor(const FileDescriptor fd) noexcept { _fd = fd; }
 
     /**
      * @brief Check the usage of encryption port (used for HTTPS)
      */
-    [[nodiscard]] bool hasEncryption(void) const noexcept { return _useEncryption; }
+    [[nodiscard]] inline bool hasEncryption(void) const noexcept { return _useEncryption; }
 
     /**
      * @brief Set the encryption state
      */
-    void setEncryption(const bool value) noexcept { _useEncryption = value; }
+    inline void setEncryption(const bool value) noexcept { _useEncryption = value; }
 
 private:
     ByteArray _byteArray {};

--- a/openZia/Pipeline.hpp
+++ b/openZia/Pipeline.hpp
@@ -106,12 +106,12 @@ public:
     /**
      * @brief Get internal loaded modules
      */
-    [[nodiscard]] ModuleList &getModules(void) noexcept { return _modules; }
+    [[nodiscard]] inline ModuleList &getModules(void) noexcept { return _modules; }
 
     /**
      * @brief Get internal loaded modules (const)
      */
-    [[nodiscard]] const ModuleList &getModules(void) const noexcept { return _modules; }
+    [[nodiscard]] inline const ModuleList &getModules(void) const noexcept { return _modules; }
 
     /**
      * @brief Emplaces a new module in the pipeline.

--- a/openZia/RequestHTTP.hpp
+++ b/openZia/RequestHTTP.hpp
@@ -31,33 +31,32 @@ public:
     /**
      * @brief Get request's URI reference
      */
-    [[nodiscard]] URI &getURI(void) noexcept { return _uri; }
+    [[nodiscard]] inline URI &getURI(void) noexcept { return _uri; }
 
     /**
      * @brief Get request's URI constant reference
      */
-    [[nodiscard]] const URI &getURI(void) const noexcept { return _uri; }
+    [[nodiscard]] inline const URI &getURI(void) const noexcept { return _uri; }
 
     /**
      * @brief Get request's QueryParameters reference
      */
-    [[nodiscard]] QueryParameters &getQueryParameters(void) noexcept { return _queryParameters; }
+    [[nodiscard]] inline QueryParameters &getQueryParameters(void) noexcept { return _queryParameters; }
 
     /**
      * @brief Get request's QueryParameters constant reference
      */
-    [[nodiscard]] const QueryParameters &getQueryParameters(void) const noexcept { return _queryParameters; }
-
+    [[nodiscard]] inline const QueryParameters &getQueryParameters(void) const noexcept { return _queryParameters; }
 
     /**
      * @brief Get request's method
      */
-    [[nodiscard]] Method getMethod(void) const noexcept { return _method; }
+    [[nodiscard]] inline Method getMethod(void) const noexcept { return _method; }
 
     /**
      * @brief Set request's method
      */
-    void setMethod(const Method method) noexcept { _method = method; }
+    inline void setMethod(const Method method) noexcept { _method = method; }
 
 private:
     URI _uri {};

--- a/openZia/ResponseHTTP.hpp
+++ b/openZia/ResponseHTTP.hpp
@@ -26,22 +26,22 @@ public:
     /**
      * @brief Get request's code
      */
-    [[nodiscard]] Code getCode(void) const noexcept { return _code; }
+    [[nodiscard]] inline Code getCode(void) const noexcept { return _code; }
 
     /**
      * @brief Set request's code
      */
-    void setCode(const Code code) noexcept { _code = code; }
+    inline void setCode(const Code code) noexcept { _code = code; }
 
     /**
      * @brief Get request's Reason reference
      */
-    [[nodiscard]] Reason &getReason(void) noexcept { return _reason; }
+    [[nodiscard]] inline Reason &getReason(void) noexcept { return _reason; }
 
     /**
      * @brief Get request's Reason constant reference
      */
-    [[nodiscard]] const Reason &getReason(void) const noexcept { return _reason; }
+    [[nodiscard]] inline const Reason &getReason(void) const noexcept { return _reason; }
 
 private:
     Reason _reason {};


### PR DESCRIPTION
fix: include winsock2 to avoid multiple include

refactor: add inline keyword for function definition in header included multiple times