### PR TITLE
Define FileDescriptor as a SOCKET on Windows

### DIFF
--- a/openZia/Endpoint.hpp
+++ b/openZia/Endpoint.hpp
@@ -12,17 +12,13 @@
 #include <cinttypes>
 #include "OperatingSystem.hpp"
 
-#if defined(SYSTEM_WINDOWS)
-    #include <winsock2.h>
-#endif
-
 namespace oZ
 {
     class Endpoint;
 
     using IP = std::uint32_t;
     using Port = std::uint16_t;
-    
+
     #if defined(SYSTEM_LINUX) || defined(SYSTEM_DARWIN)
         using FileDescriptor = std::int32_t;
     #elif defined(SYSTEM_WINDOWS)

--- a/openZia/Endpoint.hpp
+++ b/openZia/Endpoint.hpp
@@ -10,6 +10,11 @@
 #include <cstring>
 #include <string>
 #include <cinttypes>
+#include "OperatingSystem.hpp"
+
+#if defined(SYSTEM_WINDOWS)
+    #include <winsock2.h>
+#endif
 
 namespace oZ
 {
@@ -17,7 +22,12 @@ namespace oZ
 
     using IP = std::uint32_t;
     using Port = std::uint16_t;
-    using FileDescriptor = std::int32_t;
+    
+    #if defined(SYSTEM_LINUX) || defined(SYSTEM_DARWIN)
+        using FileDescriptor = std::int32_t;
+    #elif defined(SYSTEM_WINDOWS)
+        using FileDescriptor = SOCKET;
+    #endif
 }
 
 class oZ::Endpoint

--- a/openZia/Packet.hpp
+++ b/openZia/Packet.hpp
@@ -74,6 +74,12 @@ public:
 private:
     ByteArray _byteArray {};
     Endpoint _endpoint {};
-    FileDescriptor _fd { -1 };
+
+    #if defined(SYSTEM_LINUX) || defined(SYSTEM_DARWIN)
+        FileDescriptor _fd { -1 };
+    #elif defined(SYSTEM_WINDOWS)
+        FileDescriptor _fd = INVALID_SOCKET;
+    #endif
+
     bool _useEncryption = false;
 };


### PR DESCRIPTION
On Windows, the sockets are not integers but `SOCKET`s.