### PR TITLE
Pragma once

### DIFF
--- a/openZia/BaseHTTP.hpp
+++ b/openZia/BaseHTTP.hpp
@@ -5,6 +5,8 @@
 ** HTTP Base definitions
 */
 
+#pragma once
+
 #include <cinttypes>
 #include <string>
 

--- a/openZia/EntryPoint.hpp
+++ b/openZia/EntryPoint.hpp
@@ -5,8 +5,7 @@
 ** EntryPoint
 */
 
-#ifndef ENTRYPOINT_HPP_
-# define ENTRYPOINT_HPP_
+#pragma once
 
 # include "OperatingSystem.hpp"
 
@@ -39,4 +38,3 @@
         return new class();                                         \
     }                                                               \
 
-#endif /* !ENTRYPOINT_HPP_ */

--- a/openZia/HeaderHTTP.ipp
+++ b/openZia/HeaderHTTP.ipp
@@ -5,6 +5,8 @@
 ** HeaderHTTP
 */
 
+#pragma once
+
 #include <stdexcept>
 
 template<typename Literal>

--- a/openZia/Log.ipp
+++ b/openZia/Log.ipp
@@ -5,6 +5,8 @@
 ** Log
 */
 
+#pragma once
+
 #include <iostream>
 
 template<typename Type>

--- a/openZia/Pipeline.ipp
+++ b/openZia/Pipeline.ipp
@@ -5,6 +5,8 @@
 ** Pipeline Abstraction
 */
 
+#pragma once
+
 template<typename ModuleType>
 void oZ::Pipeline::registerCallback(State state, Priority priority, ModuleType *target, bool(ModuleType::*callback)(Context &))
 {


### PR DESCRIPTION
Add `pragma once` when missing on header to protect from double inclusion.

I also change the `IFNDEF` protection to a pragma once to maintain consistency 