### PR TITLE
Include Windows.hpp in all cases

### DIFF
--- a/openZia/DynamicLoader.hpp
+++ b/openZia/DynamicLoader.hpp
@@ -18,8 +18,9 @@
 
 #if defined(SYSTEM_LINUX) || defined(SYSTEM_DARWIN)
 # include <dlfcn.h>
-# include "Window.hpp"
 #endif
+
+#include "Windows.hpp"
 
 namespace oZ
 {


### PR DESCRIPTION
The Windows build fails because it can't find `HMODULE`.