### PR TITLE
fix: remove rvalue on pipeline ctor

### DIFF
--- a/openZia/Pipeline.cpp
+++ b/openZia/Pipeline.cpp
@@ -23,7 +23,7 @@
 using namespace std::string_literals;
 using namespace oZ;
 
-Pipeline::Pipeline(std::string &&moduleDir, std::string &&configurationDir)
+Pipeline::Pipeline(std::string moduleDir, std::string configurationDir)
     : _moduleDir(std::move(moduleDir)), _configurationDir(std::move(configurationDir))
 {
 }

--- a/openZia/Pipeline.hpp
+++ b/openZia/Pipeline.hpp
@@ -56,7 +56,7 @@ public:
      * @param moduleDir Directory containing modules to load
      * @param configurationDir Directory containing configuration files of modules
      */
-    Pipeline(std::string &&moduleDir = "Modules", std::string &&configurationDir = "Modules/Config");
+    Pipeline(std::string moduleDir = "Modules", std::string configurationDir = "Modules/Config");
 
     /**
      * @brief Disable copy constructor to prevent useless huge copies


### PR DESCRIPTION
Before : 
```
const auto &[moduleDir, configDir] = parse_input(ac, av);
oZ::Pipeline pipeline(std::move(moduleDir), std::move(configDir));
// moduleDir and configDir no longer usable
```
After : 
```
const auto &[moduleDir, configDir] = parse_input(ac, av);
oZ::Pipeline pipeline(moduleDir, configDir);
// moduleDir and configDir still can be used
```